### PR TITLE
Concurrent modification exception in map.

### DIFF
--- a/src/main/java/com/codingpractice/FailFastMap.java
+++ b/src/main/java/com/codingpractice/FailFastMap.java
@@ -1,0 +1,19 @@
+package com.codingpractice;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class FailFastMap {
+    public static void main(String[] args) {
+        Map<Integer, String> map=new HashMap<>();
+        map.put(1,"one");
+        map.put(2,"two");
+
+        Iterator it = map.keySet().iterator();
+        while(it.hasNext()){
+            System.out.println(it.next());
+            map.put(3,"three");
+        }
+    }
+}

--- a/src/main/java/com/codingpractice/collection/model/FailFastList.java
+++ b/src/main/java/com/codingpractice/collection/model/FailFastList.java
@@ -5,7 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-public class ConcurrentModificationExDemo {
+public class FailFastList {
     public static void main(String[] args) {
         /**
          * when you try to modify a list while iterating it, it throws Concurrent modification exception.


### PR DESCRIPTION
Output:
------------------------------------------------------------------------------------------------------------------------------------
Exception in thread "main" java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1620)
	at com.codingpractice.FailFastMap.main(FailFastMap.java:15)